### PR TITLE
Add post scheduling and share/fan metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ This MCP provides a suite of AI-callable tools that connect directly to a Facebo
 | `post_image_to_facebook`         | Post an image with a caption to the Facebook page.                  |
 | `send_dm_to_user`                | Send a direct message to a user.                                    |
 | `update_post`                    | Updates an existing post's message.                                 |
+| `schedule_post`                  | Schedule a post for future publication.                     |
+| `get_page_fan_count`             | Retrieve the total number of Page fans.                     |
+| `get_post_share_count`           | Get the number of shares on a post.                         |
 
 ---
 

--- a/facebook_api.py
+++ b/facebook_api.py
@@ -53,3 +53,19 @@ class FacebookAPI:
     
     def update_post(self, post_id: str, new_message: str) -> dict[str, Any]:
         return self._request("POST", f"{post_id}", {"message": new_message})
+
+    def schedule_post(self, message: str, publish_time: int) -> dict[str, Any]:
+        params = {
+            "message": message,
+            "published": False,
+            "scheduled_publish_time": publish_time,
+        }
+        return self._request("POST", f"{PAGE_ID}/feed", params)
+
+    def get_page_fan_count(self) -> int:
+        data = self._request("GET", f"{PAGE_ID}", {"fields": "fan_count"})
+        return data.get("fan_count", 0)
+
+    def get_post_share_count(self, post_id: str) -> int:
+        data = self._request("GET", f"{post_id}", {"fields": "shares"})
+        return data.get("shares", {}).get("count", 0)

--- a/manager.py
+++ b/manager.py
@@ -99,3 +99,12 @@ class Manager:
     
     def update_post(self, post_id: str, new_message: str) -> dict[str, Any]:
         return self.api.update_post(post_id, new_message)
+
+    def schedule_post(self, message: str, publish_time: int) -> dict[str, Any]:
+        return self.api.schedule_post(message, publish_time)
+
+    def get_page_fan_count(self) -> int:
+        return self.api.get_page_fan_count()
+
+    def get_post_share_count(self, post_id: str) -> int:
+        return self.api.get_post_share_count(post_id)

--- a/server.py
+++ b/server.py
@@ -220,3 +220,27 @@ def update_post(post_id: str, new_message: str) -> dict[str, Any]:
     Output: dict of update result
     """
     return manager.update_post(post_id, new_message)
+@mcp.tool()
+def schedule_post(message: str, publish_time: int) -> dict[str, Any]:
+    """Schedule a new post for future publishing.
+    Input: message (str), publish_time (Unix timestamp)
+    Output: dict with scheduled post info
+    """
+    return manager.schedule_post(message, publish_time)
+
+@mcp.tool()
+def get_page_fan_count() -> int:
+    """Get the Page's total fan/like count.
+    Input: None
+    Output: integer fan count
+    """
+    return manager.get_page_fan_count()
+
+@mcp.tool()
+def get_post_share_count(post_id: str) -> int:
+    """Get the number of shares for a post.
+    Input: post_id (str)
+    Output: integer share count
+    """
+    return manager.get_post_share_count(post_id)
+


### PR DESCRIPTION
## Summary
- add API methods to schedule posts, fetch page fan count, and share count
- expose new features through Manager and FastMCP server
- document the new tools in README

## Testing
- `python3 -m py_compile server.py manager.py facebook_api.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_6841cadb7ab08324b53b211d7728c48c