### PR TITLE
Add bulk reaction and comment management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ This MCP provides a suite of AI-callable tools that connect directly to a Facebo
 | `schedule_post`                  | Schedule a post for future publication.                     |
 | `get_page_fan_count`             | Retrieve the total number of Page fans.                     |
 | `get_post_share_count`           | Get the number of shares on a post.                         |
+| `get_post_reactions_breakdown`   | Get all reaction counts for a post in one call.              |
+| `bulk_delete_comments`           | Delete multiple comments by ID.                              |
 
 ---
 

--- a/manager.py
+++ b/manager.py
@@ -108,3 +108,29 @@ class Manager:
 
     def get_post_share_count(self, post_id: str) -> int:
         return self.api.get_post_share_count(post_id)
+
+    def get_post_reactions_breakdown(self, post_id: str) -> dict[str, Any]:
+        """Return counts for all reaction types on a post."""
+        metrics = [
+            "post_reactions_like_total",
+            "post_reactions_love_total",
+            "post_reactions_wow_total",
+            "post_reactions_haha_total",
+            "post_reactions_sorry_total",
+            "post_reactions_anger_total",
+        ]
+        raw = self.api.get_bulk_insights(post_id, metrics)
+        results: dict[str, Any] = {}
+        for item in raw.get("data", []):
+            name = item.get("name")
+            value = item.get("values", [{}])[0].get("value")
+            results[name] = value
+        return results
+
+    def bulk_delete_comments(self, comment_ids: list[str]) -> list[dict[str, Any]]:
+        """Delete multiple comments and return their results."""
+        results = []
+        for cid in comment_ids:
+            res = self.api.delete_comment(cid)
+            results.append({"comment_id": cid, "result": res})
+        return results

--- a/server.py
+++ b/server.py
@@ -244,3 +244,15 @@ def get_post_share_count(post_id: str) -> int:
     """
     return manager.get_post_share_count(post_id)
 
+
+@mcp.tool()
+def get_post_reactions_breakdown(post_id: str) -> dict[str, Any]:
+    """Get counts for all reaction types on a post."""
+    return manager.get_post_reactions_breakdown(post_id)
+
+
+@mcp.tool()
+def bulk_delete_comments(comment_ids: list[str]) -> list[dict[str, Any]]:
+    """Delete multiple comments by ID."""
+    return manager.bulk_delete_comments(comment_ids)
+


### PR DESCRIPTION
## Summary
- add ability to fetch all reaction counts in one call
- add bulk comment deletion support
- expose these as MCP tools
- document new tools in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641cf3de588324b2a4b905df183daf