### PR TITLE
Add comment hiding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This MCP provides a suite of AI-callable tools that connect directly to a Facebo
 | `get_post_comments`              | Fetch comments on a given post.                                     |
 | `delete_post`                    | Delete a specific post by ID.                                       |
 | `delete_comment`                 | Delete a specific comment by ID.                                    |
+| `hide_comment`                   | Hide a comment from public view.                         |
+| `unhide_comment`                 | Unhide a previously hidden comment.                      |
 | `delete_comment_from_post`       | Alias for deleting a comment from a specific post.                  |
 | `filter_negative_comments`       | Filter out comments with negative sentiment keywords.               |
 | `get_number_of_comments`         | Count the number of comments on a post.                             |
@@ -50,6 +52,7 @@ This MCP provides a suite of AI-callable tools that connect directly to a Facebo
 | `get_post_share_count`           | Get the number of shares on a post.                         |
 | `get_post_reactions_breakdown`   | Get all reaction counts for a post in one call.              |
 | `bulk_delete_comments`           | Delete multiple comments by ID.                              |
+| `bulk_hide_comments`             | Hide multiple comments by ID.                    |
 
 ---
 

--- a/facebook_api.py
+++ b/facebook_api.py
@@ -29,6 +29,14 @@ class FacebookAPI:
     def delete_comment(self, comment_id: str) -> dict[str, Any]:
         return self._request("DELETE", f"{comment_id}", {})
 
+    def hide_comment(self, comment_id: str) -> dict[str, Any]:
+        """Hide a comment from the Page."""
+        return self._request("POST", f"{comment_id}", {"is_hidden": True})
+
+    def unhide_comment(self, comment_id: str) -> dict[str, Any]:
+        """Unhide a previously hidden comment."""
+        return self._request("POST", f"{comment_id}", {"is_hidden": False})
+
     def get_insights(self, post_id: str, metric: str, period: str = "lifetime") -> dict[str, Any]:
         return self._request("GET", f"{post_id}/insights", {"metric": metric, "period": period})
 

--- a/manager.py
+++ b/manager.py
@@ -24,6 +24,12 @@ class Manager:
     def delete_comment(self, comment_id: str) -> dict[str, Any]:
         return self.api.delete_comment(comment_id)
 
+    def hide_comment(self, comment_id: str) -> dict[str, Any]:
+        return self.api.hide_comment(comment_id)
+
+    def unhide_comment(self, comment_id: str) -> dict[str, Any]:
+        return self.api.unhide_comment(comment_id)
+
     def delete_comment_from_post(self, post_id: str, comment_id: str) -> dict[str, Any]:
         return self.api.delete_comment(comment_id)
 
@@ -132,5 +138,13 @@ class Manager:
         results = []
         for cid in comment_ids:
             res = self.api.delete_comment(cid)
+            results.append({"comment_id": cid, "result": res})
+        return results
+
+    def bulk_hide_comments(self, comment_ids: list[str]) -> list[dict[str, Any]]:
+        """Hide multiple comments and return their results."""
+        results = []
+        for cid in comment_ids:
+            res = self.api.hide_comment(cid)
             results.append({"comment_id": cid, "result": res})
         return results

--- a/server.py
+++ b/server.py
@@ -53,6 +53,18 @@ def delete_comment(comment_id: str) -> dict[str, Any]:
     """
     return manager.delete_comment(comment_id)
 
+
+@mcp.tool()
+def hide_comment(comment_id: str) -> dict[str, Any]:
+    """Hide a comment from public view."""
+    return manager.hide_comment(comment_id)
+
+
+@mcp.tool()
+def unhide_comment(comment_id: str) -> dict[str, Any]:
+    """Unhide a previously hidden comment."""
+    return manager.unhide_comment(comment_id)
+
 @mcp.tool()
 def delete_comment_from_post(post_id: str, comment_id: str) -> dict[str, Any]:
     """Alias to delete a comment on a post.
@@ -255,4 +267,10 @@ def get_post_reactions_breakdown(post_id: str) -> dict[str, Any]:
 def bulk_delete_comments(comment_ids: list[str]) -> list[dict[str, Any]]:
     """Delete multiple comments by ID."""
     return manager.bulk_delete_comments(comment_ids)
+
+
+@mcp.tool()
+def bulk_hide_comments(comment_ids: list[str]) -> list[dict[str, Any]]:
+    """Hide multiple comments by ID."""
+    return manager.bulk_hide_comments(comment_ids)
 


### PR DESCRIPTION
## Summary
- provide helper methods to hide and unhide comments
- expose bulk comment hiding tool via the MCP server
- document new tools in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6870cdc83d6083249546da75bf688a32